### PR TITLE
Add modular evaluation API with BERTScore and SummaC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Install base requirements
+COPY requirements/base.txt requirements/base.txt
+RUN pip install --no-cache-dir -r requirements/base.txt
+
+# Install metric specific requirements
+COPY requirements/bertscore.txt requirements/bertscore.txt
+RUN pip install --no-cache-dir -r requirements/bertscore.txt
+
+COPY requirements/summac.txt requirements/summac.txt
+RUN pip install --no-cache-dir -r requirements/summac.txt
+
+# Copy application
+COPY app app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # evaluator-test
-evaluator-test
+
+FastAPI service providing evaluation metrics for text generation.
+
+## Features
+- Supports BERTScore and SummaC metrics.
+- Modular metric registry to make it easy to add more metrics.
+- Per-metric requirement files under `requirements/` for independent version management.
+- Dockerfile for containerized deployment.
+
+## Usage
+Install base and metric requirements:
+```bash
+pip install -r requirements/base.txt
+pip install -r requirements/bertscore.txt
+pip install -r requirements/summac.txt
+```
+Run the API:
+```bash
+uvicorn app.main:app --reload
+```
+
+## API
+`POST /evaluate` expects a JSON body:
+```json
+{
+  "candidate": "generated text",
+  "reference": "reference text",
+  "metrics": ["bertscore", "summac"]
+}
+```
+Response example:
+```json
+{
+  "bertscore": 0.89,
+  "summac": 0.75
+}
+```
+
+## Docker
+Build and run with Docker:
+```bash
+docker build -t evaluator .
+docker run -p 8000:8000 evaluator
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# Application package

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,29 @@
+from typing import List, Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .metrics import MetricRegistry
+
+app = FastAPI()
+
+
+class EvaluationRequest(BaseModel):
+    candidate: str
+    reference: str
+    metrics: List[str] = ["bertscore", "summac"]
+
+
+@app.post("/evaluate")
+def evaluate(request: EvaluationRequest) -> Dict[str, float]:
+    results: Dict[str, float] = {}
+    for name in request.metrics:
+        try:
+            metric = MetricRegistry.get(name)
+        except KeyError:
+            raise HTTPException(status_code=400, detail=f"Metric '{name}' is not available")
+        try:
+            results[name] = metric.evaluate(request.candidate, request.reference)
+        except ImportError as e:
+            raise HTTPException(status_code=500, detail=str(e))
+    return results

--- a/app/metrics/__init__.py
+++ b/app/metrics/__init__.py
@@ -1,0 +1,5 @@
+from .base import MetricRegistry
+from . import bertscore  # noqa: F401
+from . import summac  # noqa: F401
+
+__all__ = ["MetricRegistry"]

--- a/app/metrics/base.py
+++ b/app/metrics/base.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class Metric(ABC):
+    """Abstract base class for evaluation metrics."""
+
+    name: str
+
+    @abstractmethod
+    def evaluate(self, prediction: str, reference: str) -> float:
+        """Compute a score for a prediction/reference pair."""
+
+
+class MetricRegistry:
+    """Registry to keep track of available metrics."""
+
+    _metrics: Dict[str, Metric] = {}
+
+    @classmethod
+    def register(cls, metric: Metric) -> None:
+        cls._metrics[metric.name] = metric
+
+    @classmethod
+    def get(cls, name: str) -> Metric:
+        if name not in cls._metrics:
+            raise KeyError(f"Metric '{name}' is not registered")
+        return cls._metrics[name]
+
+    @classmethod
+    def available(cls) -> Dict[str, Metric]:
+        return dict(cls._metrics)

--- a/app/metrics/bertscore.py
+++ b/app/metrics/bertscore.py
@@ -1,0 +1,17 @@
+from .base import Metric, MetricRegistry
+
+
+class BertScoreMetric(Metric):
+    name = "bertscore"
+
+    def evaluate(self, prediction: str, reference: str) -> float:
+        try:
+            from bert_score import score
+        except ImportError as e:
+            raise ImportError("bertscore library is not installed") from e
+
+        P, R, F1 = score([prediction], [reference], lang="en", model_type="bert-base-uncased")
+        return float(F1.mean())
+
+
+MetricRegistry.register(BertScoreMetric())

--- a/app/metrics/summac.py
+++ b/app/metrics/summac.py
@@ -1,0 +1,23 @@
+from .base import Metric, MetricRegistry
+
+
+class SummaCMetric(Metric):
+    name = "summac"
+
+    def __init__(self) -> None:
+        self._model = None
+
+    def evaluate(self, prediction: str, reference: str) -> float:
+        try:
+            from summac.model_summac import SummaCZS
+        except ImportError as e:
+            raise ImportError("summac library is not installed") from e
+
+        if self._model is None:
+            self._model = SummaCZS(granularity="sentence", base_model="vitc")
+
+        scores = self._model.score([reference], [prediction])
+        return float(scores["scores"][0])
+
+
+MetricRegistry.register(SummaCMetric())

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.0
+uvicorn==0.23.2

--- a/requirements/bertscore.txt
+++ b/requirements/bertscore.txt
@@ -1,0 +1,2 @@
+bertscore==0.3.13
+torch>=1.13.0

--- a/requirements/summac.txt
+++ b/requirements/summac.txt
@@ -1,0 +1,3 @@
+summac==0.0.7
+transformers>=4.30.0
+sentencepiece>=0.1.99


### PR DESCRIPTION
## Summary
- implement FastAPI `/evaluate` endpoint
- add BERTScore and SummaC metrics with registry-based architecture
- separate per-metric dependency files and Dockerfile for container builds

## Testing
- `python -m py_compile $(find app -name '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be2c390be883218ad98d0398743935