### PR TITLE
Translate English inputs to Korean before evaluation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,26 @@
 from typing import List, Dict
+import re
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+from deep_translator import GoogleTranslator
 
 from .metrics import MetricRegistry
 
 app = FastAPI()
+
+
+_translator = GoogleTranslator(source="auto", target="ko")
+
+
+def _maybe_translate(text: str) -> str:
+    """Translate English text to Korean before evaluation."""
+    if re.search(r"[A-Za-z]", text):
+        try:
+            return _translator.translate(text)
+        except Exception:
+            return text
+    return text
 
 
 class EvaluationRequest(BaseModel):
@@ -16,6 +31,8 @@ class EvaluationRequest(BaseModel):
 
 @app.post("/evaluate")
 def evaluate(request: EvaluationRequest) -> Dict[str, float]:
+    candidate = _maybe_translate(request.candidate)
+    reference = _maybe_translate(request.reference)
     results: Dict[str, float] = {}
     for name in request.metrics:
         try:
@@ -23,7 +40,7 @@ def evaluate(request: EvaluationRequest) -> Dict[str, float]:
         except KeyError:
             raise HTTPException(status_code=400, detail=f"Metric '{name}' is not available")
         try:
-            results[name] = metric.evaluate(request.candidate, request.reference)
+            results[name] = metric.evaluate(candidate, reference)
         except ImportError as e:
             raise HTTPException(status_code=500, detail=str(e))
     return results

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 fastapi==0.110.0
 uvicorn==0.23.2
+deep-translator==1.11.4


### PR DESCRIPTION
## Summary
- Detect English text in candidate and reference and translate to Korean before scoring
- Add deep-translator dependency to handle automatic translation

## Testing
- `pip install -r requirements/base.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.0)*
- `python -m py_compile app/main.py`
- `python - <<'PY'\nfrom app.main import _maybe_translate\nprint(_maybe_translate('hello'))\nPY` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c0df7d8fbc83219cfbc781128b5313