### PR TITLE
Add timeout and cancellation handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Run the API:
 uvicorn app.main:app --reload
 ```
 
+### Configuration
+
+Set `METRIC_TIMEOUT` (seconds) to control how long each metric evaluation is allowed to run.
+The default is 10 seconds.
+
 ## API
 `POST /evaluate` expects a JSON body:
 ```json

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,26 @@
 from typing import List, Dict
+import asyncio
+import logging
+import os
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from pydantic import BaseModel
 
 from .metrics import MetricRegistry
 
 app = FastAPI()
+
+
+METRIC_TIMEOUT = float(os.getenv("METRIC_TIMEOUT", "10"))
+
+
+@app.middleware("http")
+async def cancel_middleware(request: Request, call_next):
+    try:
+        return await call_next(request)
+    except asyncio.CancelledError:
+        logging.warning("Request cancelled by client")
+        return Response(status_code=499)
 
 
 class EvaluationRequest(BaseModel):
@@ -15,15 +30,26 @@ class EvaluationRequest(BaseModel):
 
 
 @app.post("/evaluate")
-def evaluate(request: EvaluationRequest) -> Dict[str, float]:
+async def evaluate(request: Request, payload: EvaluationRequest) -> Dict[str, float]:
     results: Dict[str, float] = {}
-    for name in request.metrics:
+    for name in payload.metrics:
         try:
             metric = MetricRegistry.get(name)
         except KeyError:
             raise HTTPException(status_code=400, detail=f"Metric '{name}' is not available")
         try:
-            results[name] = metric.evaluate(request.candidate, request.reference)
+            results[name] = await asyncio.wait_for(
+                asyncio.to_thread(metric.evaluate, payload.candidate, payload.reference),
+                timeout=METRIC_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            raise HTTPException(status_code=504, detail=f"Metric '{name}' evaluation timed out")
+        except asyncio.CancelledError:
+            logging.info("Metric evaluation cancelled")
+            raise
         except ImportError as e:
             raise HTTPException(status_code=500, detail=str(e))
+        if await request.is_disconnected():
+            logging.info("Client disconnected during evaluation")
+            raise asyncio.CancelledError()
     return results


### PR DESCRIPTION
## Summary
- add middleware to handle client cancellations
- apply configurable asyncio timeout to metric evaluation calls
- document METRIC_TIMEOUT configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0e91cf0648321bae0c036391d82b9