### PR TITLE
Preload SummaC metric at application startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,11 @@ from .metrics import MetricRegistry
 
 app = FastAPI()
 
+@app.on_event("startup")
+def load_summac_model() -> None:
+    MetricRegistry.get("summac")
+
+
 
 class EvaluationRequest(BaseModel):
     candidate: str


### PR DESCRIPTION
## Summary
- Load the SummaC metric during FastAPI startup so its NLI model is initialized early

## Testing
- `pytest`
- `python - <<'PY'
# stub transformers to avoid heavy deps and verify load-once behavior
import types, sys
transformers_stub = types.ModuleType('transformers')
class Dummy:
    @staticmethod
    def from_pretrained(*args, **kwargs):
        return object()
transformers_stub.AutoTokenizer = Dummy
transformers_stub.AutoModelForSequenceClassification = Dummy
def pipeline(*args, **kwargs):
    return object()
transformers_stub.pipeline = pipeline
sys.modules['transformers'] = transformers_stub

import app.metrics.summac as summac

def dummy_load_nli(model_name: str):
    print('stub load')
    return object()

summac.load_nli = dummy_load_nli
summac.summac_like_score = lambda *args, **kwargs: {'score': 0.0}

from app.metrics import MetricRegistry
metric = MetricRegistry.get('summac')
print('First evaluation')
metric.evaluate('a', 'b')
print('Second evaluation')
metric.evaluate('c', 'd')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c0e91d14ac8321952d4e4a3fa12b27