### PR TITLE
Run evaluator with multiple workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ ENV OMP_NUM_THREADS=1
 ENV PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:32
 
 # Run with more memory (for Docker command)
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]

--- a/app/metrics/__init__.py
+++ b/app/metrics/__init__.py
@@ -1,5 +1,6 @@
 from .base import MetricRegistry
 from . import bertscore  # noqa: F401
 from . import summac  # noqa: F401
+from . import slow  # noqa: F401
 
 __all__ = ["MetricRegistry"]

--- a/app/metrics/slow.py
+++ b/app/metrics/slow.py
@@ -1,0 +1,16 @@
+import time
+from .base import Metric, MetricRegistry
+
+
+class SlowMetric(Metric):
+    """Metric that simulates a long-running computation."""
+
+    name = "slow"
+
+    def evaluate(self, prediction: str, reference: str) -> float:
+        # Simulate a heavy computation that takes 5 seconds
+        time.sleep(5)
+        return 0.0
+
+
+MetricRegistry.register(SlowMetric())


### PR DESCRIPTION
## Summary
- run uvicorn with two worker processes for parallel request handling
- add a `slow` metric for simulating long-running evaluations

## Testing
- `pip install -r requirements/base.txt` *(fails: 403 Forbidden)*
- `uvicorn app.main:app --workers 2` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e91d20e483218f3be481458ba614